### PR TITLE
Hook for other addons

### DIFF
--- a/modules/ModuleTagListByCategory.php
+++ b/modules/ModuleTagListByCategory.php
@@ -117,7 +117,6 @@ class ModuleTagListByCategory extends \Module
 								$this->import($callback[0]);
 								$arrTagTemplates[] = $this->$callback[0]->$callback[1]($sourcetable,$tagid_cats[$sourcetable]);
 							}
-							print_r($arrTagTemplates);
 							$this->Template->other_pages = $arrTagTemplates;
 						}
 						break;

--- a/modules/ModuleTagListByCategory.php
+++ b/modules/ModuleTagListByCategory.php
@@ -110,6 +110,17 @@ class ModuleTagListByCategory extends \Module
 						$this->Template->articles = $this->getArticlesForArticleTags($tagid_cats[$sourcetable]);
 						$pages = array_merge($pages, $this->getPagesForArticleTags($tagid_cats[$sourcetable]));
 						break;
+					default:
+						if (isset($GLOBALS['TL_HOOKS']['tagSourceTable']) && is_array($GLOBALS['TL_HOOKS']['tagSourceTable'])) {
+							$arrTagTemplates = array();
+							foreach ($GLOBALS['TL_HOOKS']['tagSourceTable'] as $type => $callback) {
+								$this->import($callback[0]);
+								$arrTagTemplates[] = $this->$callback[0]->$callback[1]($sourcetable,$tagid_cats[$sourcetable]);
+							}
+							print_r($arrTagTemplates);
+							$this->Template->other_pages = $arrTagTemplates;
+						}
+						break;
 				}
 			}
 			$uniquepages = array();

--- a/modules/ModuleTagListByCategory.php
+++ b/modules/ModuleTagListByCategory.php
@@ -115,7 +115,7 @@ class ModuleTagListByCategory extends \Module
 							$arrTagTemplates = array();
 							foreach ($GLOBALS['TL_HOOKS']['tagSourceTable'] as $type => $callback) {
 								$this->import($callback[0]);
-								$arrTagTemplates[] = $this->$callback[0]->$callback[1]($sourcetable,$tagid_cats[$sourcetable]);
+								$arrTagTemplates = array_merge($arrTagTemplates,$this->$callback[0]->$callback[1]($sourcetable,$tagid_cats[$sourcetable]));
 							}
 							$this->Template->other_pages = $arrTagTemplates;
 						}

--- a/templates/modules/mod_tag_listbycategory.html5
+++ b/templates/modules/mod_tag_listbycategory.html5
@@ -26,9 +26,19 @@
 <h3><?php echo $this->lngPages; ?></h3>
 <ul>
 <?php foreach ($this->pages as $page): ?>
-	<li>
-		{{link::<?php echo $page['alias']; ?>}}
-	</li>
+  <li>
+    {{link::<?php echo $page['alias']; ?>}}
+  </li>
+<?php endforeach; ?>
+</ul>
+<?php endif; ?>
+<?php if (count($this->other_pages)): ?>
+<h3><?php echo $this->lngOtherPages; ?></h3>
+<ul>
+<?php foreach ($this->other_pages as $url): ?>
+  <li>
+    <?php echo $url; ?>
+  </li>
 <?php endforeach; ?>
 </ul>
 <?php endif; ?>

--- a/templates/modules/mod_tag_listbycategory.xhtml
+++ b/templates/modules/mod_tag_listbycategory.xhtml
@@ -32,4 +32,14 @@
 <?php endforeach; ?>
 </ul>
 <?php endif; ?>
+<?php if (count($this->other_pages)): ?>
+<h3><?php echo $this->lngOtherPages; ?></h3>
+<ul>
+<?php foreach ($this->other_pages as $url): ?>
+  <li>
+    <?php echo $url; ?>
+  </li>
+<?php endforeach; ?>
+</ul>
+<?php endif; ?>
 </div>


### PR DESCRIPTION
Ho! 

Ich wurde gefragt ob ich mein Addon "Glossar" mit Tags kompatibel gestalten könnte. Das war soweit kein Problem, lediglich die Tag-Clouds bzw. das Modul "Kategorisierte Auszeichnungsliste" kann - soweit ich das gesehen habe - die URLs nicht finden. Mit dem PR hier, bekommt das Modul einen Hook mit dem ich URLs hinzufügen könnte.

Wie findest du das? Ggf. müssten wir sonst noch den Hook umbenennen :)
Meinst du das könntest du aufnehmen?

_Edit:_ Ich habe eben noch ein paar Fehler ausgebügelt

Danke&Lg
Sascha
