### PR TITLE
Extension blocks 2 core functions for forwarding the news/events

### DIFF
--- a/classes/ContentHeadlineTags.php
+++ b/classes/ContentHeadlineTags.php
@@ -18,7 +18,7 @@ class ContentHeadlineTags extends \ContentHeadline
 	 */
 	public function generate()
 	{
-		if (TL_MODE == 'FE') if ($this->tagsonly) if (!strlen(\Input::get('tag'))) return;
+		if (TL_MODE == 'FE') if ($this->tagsonly) if (!strlen(\Input::get('tag', true))) return;
 		return parent::generate();
 	}
 }

--- a/classes/ContentHeadlineTags.php
+++ b/classes/ContentHeadlineTags.php
@@ -18,7 +18,7 @@ class ContentHeadlineTags extends \ContentHeadline
 	 */
 	public function generate()
 	{
-		if (TL_MODE == 'FE') if ($this->tagsonly) if (!strlen(\Input::get('tag', true))) return;
+		if (TL_MODE == 'FE') if ($this->tagsonly) if (!strlen(urldecode(\Input::get('tag', true)))) return;
 		return parent::generate();
 	}
 }

--- a/classes/TagHelper.php
+++ b/classes/TagHelper.php
@@ -47,7 +47,7 @@ class TagHelper extends \Backend
 			}
 		}
 	}
-	
+
 	public static function getSavedURLParams($objInput)
 	{
 		$strParams = '';
@@ -70,7 +70,7 @@ class TagHelper extends \Backend
 		}
 		return $strParams;
 	}
-	
+
 	/*
 	* Cleanup all tags that are associated to no longer existing TYPOlight objects
 	*/
@@ -106,7 +106,7 @@ class TagHelper extends \Backend
 			}
 		}
 	}
-	
+
 	/**
 	 * Read tags from database
 	 * @return string
@@ -120,12 +120,12 @@ class TagHelper extends \Backend
 
 	public function sortByRelevance($a, $b)
 	{
-		if ($a['tagcount'] == $b['tagcount']) 
+		if ($a['tagcount'] == $b['tagcount'])
 		{
 			return 0;
 		}
 		return ($a['tagcount'] < $b['tagcount']) ? 1 : -1;
-	} 
+	}
 
 	private function getTagsForTableAndId($table, $id, $url = false, $max_tags = 0, $relevance = 0, $target = 0)
 	{
@@ -199,16 +199,16 @@ class TagHelper extends \Backend
 		}
 		return $res;
 	}
-	
+
 	public function replaceTagInsertTags($strTag)
 	{
 		if ($strTag == 'tags_used')
 		{
 			$headlinetags = array();
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			if (strlen($this->Input->get('tag')))
+			if (strlen($this->Input->get('tag', true)))
 			{
-				$headlinetags = array_merge($headlinetags, array($this->Input->get('tag')));
+				$headlinetags = array_merge($headlinetags, array($this->Input->get('tag', true)));
 				if (count($relatedlist))
 				{
 					$headlinetags = array_merge($headlinetags, $relatedlist);
@@ -291,7 +291,7 @@ class TagHelper extends \Backend
 			$objTemplate->taglist = $taglist;
 		}
 	}
-	
+
 	public function getTagsAndTaglistForIdAndTable($id, $table, $jumpto)
 	{
 		$pageArr = array();
@@ -325,7 +325,7 @@ class TagHelper extends \Backend
 			'taglist' => $taglist
 		);
 	}
-	
+
 	/**
 	 * Check for modified calendar feeds and update the XML files if necessary
 	 */

--- a/classes/TagHelper.php
+++ b/classes/TagHelper.php
@@ -206,9 +206,9 @@ class TagHelper extends \Backend
 		{
 			$headlinetags = array();
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			if (strlen($this->Input->get('tag', true)))
+			if (strlen(urldecode($this->Input->get('tag', true))))
 			{
-				$headlinetags = array_merge($headlinetags, array($this->Input->get('tag', true)));
+				$headlinetags = array_merge($headlinetags, array(urldecode($this->Input->get('tag', true))));
 				if (count($relatedlist))
 				{
 					$headlinetags = array_merge($headlinetags, $relatedlist);

--- a/classes/TagMemberHelper.php
+++ b/classes/TagMemberHelper.php
@@ -21,10 +21,10 @@ class TagMemberHelper extends \Backend
 {
 	public function setMemberlistOptions($moduleMemberList)
 	{
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$tagids = array();
 			$first = true;
 			foreach ($alltags as $tag)

--- a/classes/TagMemberHelper.php
+++ b/classes/TagMemberHelper.php
@@ -21,10 +21,10 @@ class TagMemberHelper extends \Backend
 {
 	public function setMemberlistOptions($moduleMemberList)
 	{
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$tagids = array();
 			$first = true;
 			foreach ($alltags as $tag)

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "contao/core-bundle": "~4.4",
     "contao-community-alliance/composer-plugin": "~3.0"
   },
+  "replace": {
+    "hschottm/tags": "~4.0"
+  },
   "extra":{
     "contao": {
       "sources":{

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":"hschottm/tags",
+  "name":"qzminski/hschottm-tags",
   "description":"tags is a Contao extension that provides an architecture to tag any Contao element.",
   "keywords":["contao", "module", "extension", "tagcloud", "tags"],
   "type":"contao-module",

--- a/elements/ContentGalleryTags.php
+++ b/elements/ContentGalleryTags.php
@@ -19,12 +19,12 @@ class ContentGalleryTags extends ContentGallery
 	{
 		$newMultiSRC = array();
 
-		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+		if ((strlen(urldecode(\Input::get('tag', true))) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$first = true;
 			if (strlen($this->tag_filter))
 			{

--- a/elements/ContentGalleryTags.php
+++ b/elements/ContentGalleryTags.php
@@ -19,12 +19,12 @@ class ContentGalleryTags extends ContentGallery
 	{
 		$newMultiSRC = array();
 
-		if ((strlen(\Input::get('tag')) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$first = true;
 			if (strlen($this->tag_filter))
 			{

--- a/modules/ModuleCalendarTags.php
+++ b/modules/ModuleCalendarTags.php
@@ -26,14 +26,14 @@ class ModuleCalendarTags extends \ModuleCalendar
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (($this->tag_ignore) && !strlen($this->tag_filter)) return $arrAllEvents;
-		if (strlen(\Input::get('tag')) || strlen($this->tag_filter))
+		if (strlen(\Input::get('tag', true)) || strlen($this->tag_filter))
 		{
 			$limit = null;
 			$offset = 0;
 			$tagids = array();
 			if (strlen($this->tag_filter)) $tagids = $this->getFilterTags();
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$tagArray = (strlen(\Input::get('tag'))) ? array(\Input::get('tag')) : array();
+			$tagArray = (strlen(\Input::get('tag', true))) ? array(\Input::get('tag', true)) : array();
 			$alltags = array_merge($tagArray, $relatedlist);
 			foreach ($alltags as $tag)
 			{

--- a/modules/ModuleCalendarTags.php
+++ b/modules/ModuleCalendarTags.php
@@ -26,14 +26,14 @@ class ModuleCalendarTags extends \ModuleCalendar
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (($this->tag_ignore) && !strlen($this->tag_filter)) return $arrAllEvents;
-		if (strlen(\Input::get('tag', true)) || strlen($this->tag_filter))
+		if (strlen(urldecode(\Input::get('tag', true))) || strlen($this->tag_filter))
 		{
 			$limit = null;
 			$offset = 0;
 			$tagids = array();
 			if (strlen($this->tag_filter)) $tagids = $this->getFilterTags();
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$tagArray = (strlen(\Input::get('tag', true))) ? array(\Input::get('tag', true)) : array();
+			$tagArray = (strlen(urldecode(\Input::get('tag', true)))) ? array(urldecode(\Input::get('tag', true))) : array();
 			$alltags = array_merge($tagArray, $relatedlist);
 			foreach ($alltags as $tag)
 			{

--- a/modules/ModuleEventlistTags.php
+++ b/modules/ModuleEventlistTags.php
@@ -22,7 +22,7 @@ class ModuleEventlistTags extends \ModuleEventlist
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (($this->tag_ignore) && !strlen($this->tag_filter)) return $arrAllEvents;
 
-		if (strlen(\Input::get('tag', true)) || strlen($this->tag_filter))
+		if (strlen(urldecode(\Input::get('tag', true))) || strlen($this->tag_filter))
 		{
 			$limit = null;
 			$offset = 0;
@@ -30,7 +30,7 @@ class ModuleEventlistTags extends \ModuleEventlist
 			if (strlen($this->tag_filter)) $tagids = $this->getFilterTags();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$tagArray = (strlen(\Input::get('tag', true))) ? array(\Input::get('tag', true)) : array();
+			$tagArray = (strlen(urldecode(\Input::get('tag', true)))) ? array(urldecode(\Input::get('tag', true))) : array();
 			$alltags = array_merge($tagArray, $relatedlist);
 			foreach ($alltags as $tag)
 			{
@@ -373,7 +373,7 @@ class ModuleEventlistTags extends \ModuleEventlist
 
      ////////// CHANGES BY ModuleEventlistTags
  		$headlinetags = array();
- 		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+ 		if ((strlen(urldecode(\Input::get('tag', true))) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
  		{
  			if (strlen($this->tag_filter))
  			{
@@ -386,7 +386,7 @@ class ModuleEventlistTags extends \ModuleEventlist
  				$headlinetags = array();
  			}
  			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
- 			$tagArray = (strlen(\Input::get('tag', true))) ? array(\Input::get('tag', true)) : array();
+ 			$tagArray = (strlen(urldecode(\Input::get('tag', true)))) ? array(urldecode(\Input::get('tag', true))) : array();
  			$headlinetags = array_merge($headlinetags, $tagArray);
  			if (count($relatedlist))
  			{
@@ -395,7 +395,7 @@ class ModuleEventlistTags extends \ModuleEventlist
  		}
  		if (strlen($this->Template->events) == 0)
  		{
- 			$headlinetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+ 			$headlinetags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
  			$this->Template->events = $GLOBALS['TL_LANG']['MSC']['emptyevents'];
  		}
  		$this->Template->tags_activetags = $headlinetags;

--- a/modules/ModuleEventlistTags.php
+++ b/modules/ModuleEventlistTags.php
@@ -22,7 +22,7 @@ class ModuleEventlistTags extends \ModuleEventlist
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (($this->tag_ignore) && !strlen($this->tag_filter)) return $arrAllEvents;
 
-		if (strlen(\Input::get('tag')) || strlen($this->tag_filter))
+		if (strlen(\Input::get('tag', true)) || strlen($this->tag_filter))
 		{
 			$limit = null;
 			$offset = 0;
@@ -30,7 +30,7 @@ class ModuleEventlistTags extends \ModuleEventlist
 			if (strlen($this->tag_filter)) $tagids = $this->getFilterTags();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$tagArray = (strlen(\Input::get('tag'))) ? array(\Input::get('tag')) : array();
+			$tagArray = (strlen(\Input::get('tag', true))) ? array(\Input::get('tag', true)) : array();
 			$alltags = array_merge($tagArray, $relatedlist);
 			foreach ($alltags as $tag)
 			{
@@ -373,7 +373,7 @@ class ModuleEventlistTags extends \ModuleEventlist
 
      ////////// CHANGES BY ModuleEventlistTags
  		$headlinetags = array();
- 		if ((strlen(\Input::get('tag')) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+ 		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
  		{
  			if (strlen($this->tag_filter))
  			{
@@ -386,7 +386,7 @@ class ModuleEventlistTags extends \ModuleEventlist
  				$headlinetags = array();
  			}
  			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
- 			$tagArray = (strlen(\Input::get('tag'))) ? array(\Input::get('tag')) : array();
+ 			$tagArray = (strlen(\Input::get('tag', true))) ? array(\Input::get('tag', true)) : array();
  			$headlinetags = array_merge($headlinetags, $tagArray);
  			if (count($relatedlist))
  			{
@@ -395,7 +395,7 @@ class ModuleEventlistTags extends \ModuleEventlist
  		}
  		if (strlen($this->Template->events) == 0)
  		{
- 			$headlinetags = array_merge(array(\Input::get('tag')), $relatedlist);
+ 			$headlinetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
  			$this->Template->events = $GLOBALS['TL_LANG']['MSC']['emptyevents'];
  		}
  		$this->Template->tags_activetags = $headlinetags;

--- a/modules/ModuleFaqListTags.php
+++ b/modules/ModuleFaqListTags.php
@@ -19,10 +19,10 @@ class ModuleFaqListTags extends \ModuleFaqList
 	protected function compile()
 	{
 		$tagids = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$first = true;
 			foreach ($alltags as $tag)
 			{

--- a/modules/ModuleFaqListTags.php
+++ b/modules/ModuleFaqListTags.php
@@ -19,10 +19,10 @@ class ModuleFaqListTags extends \ModuleFaqList
 	protected function compile()
 	{
 		$tagids = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$first = true;
 			foreach ($alltags as $tag)
 			{

--- a/modules/ModuleGlobalArticlelist.php
+++ b/modules/ModuleGlobalArticlelist.php
@@ -65,13 +65,13 @@ class ModuleGlobalArticlelist extends \Module
 			->execute($time, $time);
 
 		$tagids = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$limit = null;
 			$offset = 0;
 
 			$objIds = $this->Database->prepare("SELECT tid FROM tl_tag WHERE from_table = ? AND tag = ?")
-				->execute('tl_article', \Input::get('tag', true));
+				->execute('tl_article', urldecode(\Input::get('tag', true)));
 			if ($objIds->numRows)
 			{
 				while ($objIds->next())
@@ -115,10 +115,10 @@ class ModuleGlobalArticlelist extends \Module
 			}
 		}
 		$headlinetags = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$headlinetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$headlinetags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 		}
 		$this->Template->tags_activetags = $headlinetags;
 		$this->Template->articles = $articles;

--- a/modules/ModuleGlobalArticlelist.php
+++ b/modules/ModuleGlobalArticlelist.php
@@ -65,13 +65,13 @@ class ModuleGlobalArticlelist extends \Module
 			->execute($time, $time);
 
 		$tagids = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$limit = null;
 			$offset = 0;
-			
+
 			$objIds = $this->Database->prepare("SELECT tid FROM tl_tag WHERE from_table = ? AND tag = ?")
-				->execute('tl_article', \Input::get('tag'));
+				->execute('tl_article', \Input::get('tag', true));
 			if ($objIds->numRows)
 			{
 				while ($objIds->next())
@@ -115,10 +115,10 @@ class ModuleGlobalArticlelist extends \Module
 			}
 		}
 		$headlinetags = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$headlinetags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$headlinetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 		}
 		$this->Template->tags_activetags = $headlinetags;
 		$this->Template->articles = $articles;

--- a/modules/ModuleLastEventsTags.php
+++ b/modules/ModuleLastEventsTags.php
@@ -18,14 +18,14 @@ class ModuleLastEventsTags extends \ModuleLastEvents
 	protected function getAllEvents($arrCalendars, $intStart, $intEnd)
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$limit = null;
 			$offset = 0;
 			$tagids = array();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			foreach ($alltags as $tag)
 			{
 				if (count($tagids))
@@ -68,14 +68,14 @@ class ModuleLastEventsTags extends \ModuleLastEvents
 	protected function compile()
 	{
 		parent::compile();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$this->Template->tags_activetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$this->Template->tags_activetags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 		}
 		if (strlen($this->Template->events) == 0)
 		{
-			$this->Template->tags_activetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$this->Template->tags_activetags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$this->Template->events = $GLOBALS['TL_LANG']['MSC']['emptyevents'];
 		}
 	}

--- a/modules/ModuleLastEventsTags.php
+++ b/modules/ModuleLastEventsTags.php
@@ -18,14 +18,14 @@ class ModuleLastEventsTags extends \ModuleLastEvents
 	protected function getAllEvents($arrCalendars, $intStart, $intEnd)
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$limit = null;
 			$offset = 0;
 			$tagids = array();
-			
+
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			foreach ($alltags as $tag)
 			{
 				if (count($tagids))
@@ -61,21 +61,21 @@ class ModuleLastEventsTags extends \ModuleLastEvents
 		}
 		return $arrAllEvents;
 	}
-	
+
 	/**
 	 * Generate module
 	 */
 	protected function compile()
 	{
 		parent::compile();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$this->Template->tags_activetags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$this->Template->tags_activetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 		}
 		if (strlen($this->Template->events) == 0)
 		{
-			$this->Template->tags_activetags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$this->Template->tags_activetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$this->Template->events = $GLOBALS['TL_LANG']['MSC']['emptyevents'];
 		}
 	}

--- a/modules/ModuleNewsArchiveTags.php
+++ b/modules/ModuleNewsArchiveTags.php
@@ -166,9 +166,9 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 
 		$headlinetags = array();
 
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
-			$headlinetags = array_merge($headlinetags, array(\Input::get('tag', true)));
+			$headlinetags = array_merge($headlinetags, array(urldecode(\Input::get('tag', true))));
 			if (count($relatedlist))
 			{
 				$headlinetags = array_merge($headlinetags, $relatedlist);
@@ -189,12 +189,12 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 		$this->Session->set('news_showtags', $this->news_showtags);
 		$this->Session->set('news_jumpto', $this->tag_jumpTo);
 		$this->Session->set('news_tag_named_class', $this->tag_named_class);
-		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+		if ((strlen(urldecode(\Input::get('tag', true))) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$first = true;
 			if (strlen($this->tag_filter))
 			{

--- a/modules/ModuleNewsArchiveTags.php
+++ b/modules/ModuleNewsArchiveTags.php
@@ -166,9 +166,9 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 
 		$headlinetags = array();
 
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
-			$headlinetags = array_merge($headlinetags, array(\Input::get('tag')));
+			$headlinetags = array_merge($headlinetags, array(\Input::get('tag', true)));
 			if (count($relatedlist))
 			{
 				$headlinetags = array_merge($headlinetags, $relatedlist);
@@ -180,7 +180,7 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 		$this->Template->back = $GLOBALS['TL_LANG']['MSC']['goBack'];
 		$this->Template->empty = $GLOBALS['TL_LANG']['MSC']['empty'];
 	}
-	
+
 	/**
 	 * Generate module
 	 */
@@ -189,12 +189,12 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 		$this->Session->set('news_showtags', $this->news_showtags);
 		$this->Session->set('news_jumpto', $this->tag_jumpTo);
 		$this->Session->set('news_tag_named_class', $this->tag_named_class);
-		if ((strlen(\Input::get('tag')) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
-			
+
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$first = true;
 			if (strlen($this->tag_filter))
 			{

--- a/modules/ModuleNewsListTags.php
+++ b/modules/ModuleNewsListTags.php
@@ -147,9 +147,9 @@ class ModuleNewsListTags extends \ModuleNewsList
 		// new code for tags
 		$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
 		$headlinetags = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
-			$headlinetags = array_merge($headlinetags, array(\Input::get('tag', true)));
+			$headlinetags = array_merge($headlinetags, array(urldecode(\Input::get('tag', true))));
 			if (count($relatedlist))
 			{
 				$headlinetags = array_merge($headlinetags, $relatedlist);
@@ -167,12 +167,12 @@ class ModuleNewsListTags extends \ModuleNewsList
 		$this->Session->set('news_showtags', $this->news_showtags);
 		$this->Session->set('news_jumpto', $this->tag_jumpTo);
 		$this->Session->set('news_tag_named_class', $this->tag_named_class);
-		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+		if ((strlen(urldecode(\Input::get('tag', true))) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
 
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$first = true;
 			if (strlen($this->tag_filter))
 			{

--- a/modules/ModuleNewsListTags.php
+++ b/modules/ModuleNewsListTags.php
@@ -147,9 +147,9 @@ class ModuleNewsListTags extends \ModuleNewsList
 		// new code for tags
 		$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
 		$headlinetags = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
-			$headlinetags = array_merge($headlinetags, array(\Input::get('tag')));
+			$headlinetags = array_merge($headlinetags, array(\Input::get('tag', true)));
 			if (count($relatedlist))
 			{
 				$headlinetags = array_merge($headlinetags, $relatedlist);
@@ -167,12 +167,12 @@ class ModuleNewsListTags extends \ModuleNewsList
 		$this->Session->set('news_showtags', $this->news_showtags);
 		$this->Session->set('news_jumpto', $this->tag_jumpTo);
 		$this->Session->set('news_tag_named_class', $this->tag_named_class);
-		if ((strlen(\Input::get('tag')) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
+		if ((strlen(\Input::get('tag', true)) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
-			
+
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$first = true;
 			if (strlen($this->tag_filter))
 			{

--- a/modules/ModuleTagCloud.php
+++ b/modules/ModuleTagCloud.php
@@ -65,10 +65,10 @@ class ModuleTagCloud extends \Module
 		if (strlen($this->pagesource)) $taglist->pagesource = deserialize($this->pagesource, TRUE);
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen(\Input::get('tag')) && $this->tag_related)
+		if (strlen(\Input::get('tag', true)) && $this->tag_related)
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(\Input::get('tag')), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(\Input::get('tag', true)), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{
@@ -123,7 +123,7 @@ class ModuleTagCloud extends \Module
 				}
 			}
 			$this->arrTags[$idx]['tag_url'] = $strUrl;
-			if ($tag['tag_name'] == \Input::get('tag'))
+			if ($tag['tag_name'] == \Input::get('tag', true))
 			{
 				$this->arrTags[$idx]['tag_class'] .= ' active';
 			}
@@ -164,7 +164,7 @@ class ModuleTagCloud extends \Module
 		{
 			if (count($pageArr))
 			{
-				$strUrl = ampersand($this->generateFrontendUrl($pageArr, '/tag/' . \System::urlencode(\Input::get('tag')) . '/related/' . \System::urlencode(join(array_merge($relatedlist, array($tag['tag_name'])), ','))));
+				$strUrl = ampersand($this->generateFrontendUrl($pageArr, '/tag/' . \System::urlencode(\Input::get('tag', true)) . '/related/' . \System::urlencode(join(array_merge($relatedlist, array($tag['tag_name'])), ','))));
 			}
 			$this->arrRelated[$idx]['tag_url'] = $strUrl;
 		}
@@ -176,7 +176,7 @@ class ModuleTagCloud extends \Module
 		$this->Template->strAllTags = $GLOBALS['TL_LANG']['tl_module']['tag_alltags'];
 		$this->Template->strTopTenTags = sprintf($GLOBALS['TL_LANG']['tl_module']['top_tags'], $this->tag_topten_number);
 		$this->Template->tagcount = count($this->arrTags);
-		$this->Template->selectedtags = (strlen(\Input::get('tag'))) ? (count($this->arrRelated)+1) : 0;
+		$this->Template->selectedtags = (strlen(\Input::get('tag', true))) ? (count($this->arrRelated)+1) : 0;
 		if ($this->tag_show_reset)
 		{
 			$strEmptyUrl = ampersand($this->generateFrontendUrl($pageArr, ''));

--- a/modules/ModuleTagCloud.php
+++ b/modules/ModuleTagCloud.php
@@ -65,10 +65,10 @@ class ModuleTagCloud extends \Module
 		if (strlen($this->pagesource)) $taglist->pagesource = deserialize($this->pagesource, TRUE);
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen(\Input::get('tag', true)) && $this->tag_related)
+		if (strlen(urldecode(\Input::get('tag', true))) && $this->tag_related)
 		{
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(\Input::get('tag', true)), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{
@@ -123,7 +123,7 @@ class ModuleTagCloud extends \Module
 				}
 			}
 			$this->arrTags[$idx]['tag_url'] = $strUrl;
-			if ($tag['tag_name'] == \Input::get('tag', true))
+			if ($tag['tag_name'] == urldecode(\Input::get('tag', true)))
 			{
 				$this->arrTags[$idx]['tag_class'] .= ' active';
 			}
@@ -164,7 +164,7 @@ class ModuleTagCloud extends \Module
 		{
 			if (count($pageArr))
 			{
-				$strUrl = ampersand($this->generateFrontendUrl($pageArr, '/tag/' . \System::urlencode(\Input::get('tag', true)) . '/related/' . \System::urlencode(join(array_merge($relatedlist, array($tag['tag_name'])), ','))));
+				$strUrl = ampersand($this->generateFrontendUrl($pageArr, '/tag/' . \System::urlencode(urldecode(\Input::get('tag', true))) . '/related/' . \System::urlencode(join(array_merge($relatedlist, array($tag['tag_name'])), ','))));
 			}
 			$this->arrRelated[$idx]['tag_url'] = $strUrl;
 		}
@@ -176,7 +176,7 @@ class ModuleTagCloud extends \Module
 		$this->Template->strAllTags = $GLOBALS['TL_LANG']['tl_module']['tag_alltags'];
 		$this->Template->strTopTenTags = sprintf($GLOBALS['TL_LANG']['tl_module']['top_tags'], $this->tag_topten_number);
 		$this->Template->tagcount = count($this->arrTags);
-		$this->Template->selectedtags = (strlen(\Input::get('tag', true))) ? (count($this->arrRelated)+1) : 0;
+		$this->Template->selectedtags = (strlen(urldecode(\Input::get('tag', true)))) ? (count($this->arrRelated)+1) : 0;
 		if ($this->tag_show_reset)
 		{
 			$strEmptyUrl = ampersand($this->generateFrontendUrl($pageArr, ''));

--- a/modules/ModuleTagCloudArticles.php
+++ b/modules/ModuleTagCloudArticles.php
@@ -47,10 +47,10 @@ class ModuleTagCloudArticles extends \ModuleTagCloud
 		if (strlen($this->tag_articles)) $taglist->articles = deserialize($this->tag_articles, TRUE);
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag')) && $this->tag_related)
+		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag')), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudArticles.php
+++ b/modules/ModuleTagCloudArticles.php
@@ -47,10 +47,10 @@ class ModuleTagCloudArticles extends \ModuleTagCloud
 		if (strlen($this->tag_articles)) $taglist->articles = deserialize($this->tag_articles, TRUE);
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
+		if (strlen(urldecode($this->Input->get('tag', true))) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudContent.php
+++ b/modules/ModuleTagCloudContent.php
@@ -45,10 +45,10 @@ class ModuleTagCloudContent extends \ModuleTagCloud
 		if (strlen($this->tag_content_pages)) $taglist->content_pages = deserialize($this->tag_content_pages, TRUE);
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag')) && $this->tag_related)
+		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag')), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudContent.php
+++ b/modules/ModuleTagCloudContent.php
@@ -45,10 +45,10 @@ class ModuleTagCloudContent extends \ModuleTagCloud
 		if (strlen($this->tag_content_pages)) $taglist->content_pages = deserialize($this->tag_content_pages, TRUE);
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
+		if (strlen(urldecode($this->Input->get('tag', true))) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudEvents.php
+++ b/modules/ModuleTagCloudEvents.php
@@ -44,10 +44,10 @@ class ModuleTagCloudEvents extends \ModuleTagCloud
 		$this->arrTags = $taglist->getTagList();
 		if (strlen($this->tag_topten_number) && $this->tag_topten_number > 0) $taglist->topnumber = $this->tag_topten_number;
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag')) && $this->tag_related)
+		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag')), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudEvents.php
+++ b/modules/ModuleTagCloudEvents.php
@@ -44,10 +44,10 @@ class ModuleTagCloudEvents extends \ModuleTagCloud
 		$this->arrTags = $taglist->getTagList();
 		if (strlen($this->tag_topten_number) && $this->tag_topten_number > 0) $taglist->topnumber = $this->tag_topten_number;
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
+		if (strlen(urldecode($this->Input->get('tag', true))) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudMembers.php
+++ b/modules/ModuleTagCloudMembers.php
@@ -43,10 +43,10 @@ class ModuleTagCloudMembers extends \ModuleTagCloud
 		$this->arrTags = $taglist->getTagList();
 		if (strlen($this->tag_topten_number) && $this->tag_topten_number > 0) $taglist->topnumber = $this->tag_topten_number;
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag')) && $this->tag_related)
+		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag')), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudMembers.php
+++ b/modules/ModuleTagCloudMembers.php
@@ -43,10 +43,10 @@ class ModuleTagCloudMembers extends \ModuleTagCloud
 		$this->arrTags = $taglist->getTagList();
 		if (strlen($this->tag_topten_number) && $this->tag_topten_number > 0) $taglist->topnumber = $this->tag_topten_number;
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
-		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
+		if (strlen(urldecode($this->Input->get('tag', true))) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudNews.php
+++ b/modules/ModuleTagCloudNews.php
@@ -44,10 +44,10 @@ class ModuleTagCloudNews extends \ModuleTagCloud
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
 		if (strlen($this->tag_topten_number) && $this->tag_topten_number > 0) $taglist->topnumber = $this->tag_topten_number;
-		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
+		if (strlen(urldecode($this->Input->get('tag', true))) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagCloudNews.php
+++ b/modules/ModuleTagCloudNews.php
@@ -44,10 +44,10 @@ class ModuleTagCloudNews extends \ModuleTagCloud
 		$this->arrTags = $taglist->getTagList();
 		if ($this->tag_topten) $this->arrTopTenTags = $taglist->getTopTenTagList();
 		if (strlen($this->tag_topten_number) && $this->tag_topten_number > 0) $taglist->topnumber = $this->tag_topten_number;
-		if (strlen($this->Input->get('tag')) && $this->tag_related)
+		if (strlen($this->Input->get('tag', true)) && $this->tag_related)
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag')), $relatedlist));
+			$this->arrRelated = $taglist->getRelatedTagList(array_merge(array($this->Input->get('tag', true)), $relatedlist));
 		}
 		if (count($this->arrTags) < 1)
 		{

--- a/modules/ModuleTagContentList.php
+++ b/modules/ModuleTagContentList.php
@@ -39,7 +39,7 @@ class ModuleTagContentList extends \Module
 		$this->getTags();
 		return parent::generate();
 	}
-	
+
 	protected function getArticlesForTagSource($sourcetable)
 	{
 		$articles = array();
@@ -54,13 +54,13 @@ class ModuleTagContentList extends \Module
 			->execute($time, $time);
 
 		$tagids = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$limit = null;
 			$offset = 0;
-			
+
 			$objIds = $this->Database->prepare("SELECT tid FROM tl_tag WHERE from_table = ? AND tag = ?")
-				->execute('tl_article', \Input::get('tag'));
+				->execute('tl_article', \Input::get('tag', true));
 			if ($objIds->numRows)
 			{
 				while ($objIds->next())
@@ -96,7 +96,7 @@ class ModuleTagContentList extends \Module
 			}
 		}
 		$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-		$headlinetags = array_merge(array(\Input::get('tag')), $relatedlist);
+		$headlinetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 		$this->Template->tags_activetags = $headlinetags;
 		$this->Template->articles = $articles;
 		$this->Template->empty = $GLOBALS['TL_LANG']['MSC']['emptyarticles'];
@@ -116,7 +116,7 @@ class ModuleTagContentList extends \Module
 		}
 		return $pages;
 	}
-	
+
 	protected function getArticles()
 	{
 		$articles = array();
@@ -146,18 +146,18 @@ class ModuleTagContentList extends \Module
 		}
 		return $ctes;
 	}
-	
+
 	protected function getTags()
 	{
 		$this->arrTags = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
 			$this->arrTags = $this->Database->prepare("SELECT tid FROM tl_tag WHERE from_table = ? AND tag = ?")
-				->execute($this->tagsource, \Input::get('tag'))
+				->execute($this->tagsource, \Input::get('tag', true))
 				->fetchEach('tid');
 		}
 	}
-	
+
 	protected function getRelevantPages($page_id)
 	{
 		$objPageWithId = $this->Database->prepare("SELECT id, published, start, stop FROM tl_page WHERE pid=? ORDER BY sorting")

--- a/modules/ModuleTagContentList.php
+++ b/modules/ModuleTagContentList.php
@@ -54,13 +54,13 @@ class ModuleTagContentList extends \Module
 			->execute($time, $time);
 
 		$tagids = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$limit = null;
 			$offset = 0;
 
 			$objIds = $this->Database->prepare("SELECT tid FROM tl_tag WHERE from_table = ? AND tag = ?")
-				->execute('tl_article', \Input::get('tag', true));
+				->execute('tl_article', urldecode(\Input::get('tag', true)));
 			if ($objIds->numRows)
 			{
 				while ($objIds->next())
@@ -96,7 +96,7 @@ class ModuleTagContentList extends \Module
 			}
 		}
 		$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-		$headlinetags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+		$headlinetags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 		$this->Template->tags_activetags = $headlinetags;
 		$this->Template->articles = $articles;
 		$this->Template->empty = $GLOBALS['TL_LANG']['MSC']['emptyarticles'];
@@ -150,10 +150,10 @@ class ModuleTagContentList extends \Module
 	protected function getTags()
 	{
 		$this->arrTags = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
 			$this->arrTags = $this->Database->prepare("SELECT tid FROM tl_tag WHERE from_table = ? AND tag = ?")
-				->execute($this->tagsource, \Input::get('tag', true))
+				->execute($this->tagsource, urldecode(\Input::get('tag', true)))
 				->fetchEach('tid');
 		}
 	}

--- a/modules/ModuleTagListByCategory.php
+++ b/modules/ModuleTagListByCategory.php
@@ -42,18 +42,18 @@ class ModuleTagListByCategory extends \Module
 //		$this->getTags();
 		return parent::generate();
 	}
-	
+
  	/**
 	 * Generate module
 	 */
 	protected function compile()
 	{
-		if (strlen(\Input::get('tag')) && count($this->sourcetables) > 0)
+		if (strlen(\Input::get('tag', true)) && count($this->sourcetables) > 0)
 		{
 			$tagids = array();
 			$tagid_cats = array();
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag')), $relatedlist);
+			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
 			$first = true;
 			$marks = array();
 			foreach ($this->sourcetables as $table)

--- a/modules/ModuleTagListByCategory.php
+++ b/modules/ModuleTagListByCategory.php
@@ -48,12 +48,12 @@ class ModuleTagListByCategory extends \Module
 	 */
 	protected function compile()
 	{
-		if (strlen(\Input::get('tag', true)) && count($this->sourcetables) > 0)
+		if (strlen(urldecode(\Input::get('tag', true))) && count($this->sourcetables) > 0)
 		{
 			$tagids = array();
 			$tagid_cats = array();
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
-			$alltags = array_merge(array(\Input::get('tag', true)), $relatedlist);
+			$alltags = array_merge(array(urldecode(\Input::get('tag', true))), $relatedlist);
 			$first = true;
 			$marks = array();
 			foreach ($this->sourcetables as $table)

--- a/modules/ModuleTagScope.php
+++ b/modules/ModuleTagScope.php
@@ -40,9 +40,9 @@ class ModuleTagScope extends \Module
 
 		$this->strTemplate = (strlen($this->scope_template)) ? $this->scope_template : $this->strTemplate;
 		$this->arrTags = array();
-		if (strlen(\Input::get('tag')))
+		if (strlen(\Input::get('tag', true)))
 		{
-			array_push($this->arrTags, \Input::get('tag'));
+			array_push($this->arrTags, \Input::get('tag', true));
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
 			$this->arrTags = array_merge($this->arrTags, $relatedlist);
 		}

--- a/modules/ModuleTagScope.php
+++ b/modules/ModuleTagScope.php
@@ -40,9 +40,9 @@ class ModuleTagScope extends \Module
 
 		$this->strTemplate = (strlen($this->scope_template)) ? $this->scope_template : $this->strTemplate;
 		$this->arrTags = array();
-		if (strlen(\Input::get('tag', true)))
+		if (strlen(urldecode(\Input::get('tag', true))))
 		{
-			array_push($this->arrTags, \Input::get('tag', true));
+			array_push($this->arrTags, urldecode(\Input::get('tag', true)));
 			$relatedlist = (strlen(\Input::get('related'))) ? preg_split("/,/", \Input::get('related')) : array();
 			$this->arrTags = array_merge($this->arrTags, $relatedlist);
 		}

--- a/modules/ModuleTaggedArticleList.php
+++ b/modules/ModuleTaggedArticleList.php
@@ -193,7 +193,7 @@ class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 		$tagids = array();
 
 		$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-		$alltags = array_merge(array($this->Input->get('tag')), $relatedlist);
+		$alltags = array_merge(array($this->Input->get('tag', true)), $relatedlist);
 		$first = true;
 		foreach ($alltags as $tag)
 		{
@@ -266,10 +266,10 @@ class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 		}
 
 		$headlinetags = array();
-		if (strlen($this->Input->get('tag')))
+		if (strlen($this->Input->get('tag', true)))
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$headlinetags = array_merge(array($this->Input->get('tag')), $relatedlist);
+			$headlinetags = array_merge(array($this->Input->get('tag', true)), $relatedlist);
 		}
 		$this->Template->showTags = $this->article_showtags;
 		$this->Template->tags_activetags = $headlinetags;

--- a/modules/ModuleTaggedArticleList.php
+++ b/modules/ModuleTaggedArticleList.php
@@ -193,7 +193,7 @@ class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 		$tagids = array();
 
 		$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-		$alltags = array_merge(array($this->Input->get('tag', true)), $relatedlist);
+		$alltags = array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist);
 		$first = true;
 		foreach ($alltags as $tag)
 		{
@@ -266,10 +266,10 @@ class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 		}
 
 		$headlinetags = array();
-		if (strlen($this->Input->get('tag', true)))
+		if (strlen(urldecode($this->Input->get('tag', true))))
 		{
 			$relatedlist = (strlen($this->Input->get('related'))) ? preg_split("/,/", $this->Input->get('related')) : array();
-			$headlinetags = array_merge(array($this->Input->get('tag', true)), $relatedlist);
+			$headlinetags = array_merge(array(urldecode($this->Input->get('tag', true))), $relatedlist);
 		}
 		$this->Template->showTags = $this->article_showtags;
 		$this->Template->tags_activetags = $headlinetags;


### PR DESCRIPTION
Hello Kamil, 

I saw that you branched the original package and already fixed some issues. It seems that Helmut is not active any more. Unfortunately. 

There are a few big issues that cause some wrong behaviour of Contao. I know that you have a big knowledge about Contao and PHP. That's why I'm writing you directly to ask you to help me or more precisely all of us who want to keep using the useful extension. 

[A lot of issues are written in German](https://github.com/hschottm/tags/issues). If you want I can help you to translate them. I think that it would be great to have a continuity in the developing of this extension. 

My problem is that your and the original extensions block 2 core functions for forwarding the news/events - that means it isn't possible to set the forward link for **Articles** and **Individual URL**. I'm using Contao 4.8.4. I guess that the extension uses one of the callback functions that changed its behaviour in the last Contao versions. 

If I can help you to fix it, please let me know. I would appreciate your help very much. 

Best regards, Jan