### PR TITLE
Support Contao 4.9 with missing class tl_settings

### DIFF
--- a/dca/tl_settings.php
+++ b/dca/tl_settings.php
@@ -21,7 +21,7 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['disabledTagObjects'] = array
 	'eval'                    => array('multiple'=>true)
 );
 
-class tl_settings_tags extends tl_settings
+class tl_settings_tags extends Contao\Backend
 {
 	/**
 	 * Return available tag tables

--- a/dca/tl_settings.php
+++ b/dca/tl_settings.php
@@ -21,7 +21,7 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['disabledTagObjects'] = array
 	'eval'                    => array('multiple'=>true)
 );
 
-class tl_settings_tags extends Contao\Backend
+class tl_settings_tags
 {
 	/**
 	 * Return available tag tables


### PR DESCRIPTION
The class `tl_settings` no longer exists in Contao 4.9, so the callback function should instead extend `Contao/Backend`!