### PR TITLE
Generates wrong feeds xml

### DIFF
--- a/classes/TagHelper.php
+++ b/classes/TagHelper.php
@@ -411,7 +411,7 @@ class TagHelper extends \Backend
 
 		foreach ($session as $id)
 		{
-			$this->CalendarTags->generateFeed($id);
+			$this->CalendarTags->generateFeedsByCalendar($id);
 		}
 
 		$this->Session->set('calendar_feed_updater', null);
@@ -433,7 +433,7 @@ class TagHelper extends \Backend
 
 		foreach ($session as $id)
 		{
-			$this->NewsTags->generateFeed($id);
+			$this->NewsTags->generateFeedsByArchive($id);
 		}
 
 		$this->Session->set('news_feed_updater', null);


### PR DESCRIPTION
`News::generateFeeds` and `Calander::generateFeeds` expects `id`of the feed. But here we are passing `id`of news/calander channels.