### PR TITLE
Fix Links

### DIFF
--- a/classes/CalendarTags.php
+++ b/classes/CalendarTags.php
@@ -63,7 +63,7 @@ class CalendarTags extends \Calendar
 						}
 						else
 						{
-							$strUrl = $objPage->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objEvent->aAlias)) ? $objEvent->aAlias : $objEvent->aId));
+							$strUrl = \TagHelper::getPageObj()->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objEvent->aAlias)) ? $objEvent->aAlias : $objEvent->aId));
 						}
 						break;
 				}

--- a/classes/TagHelper.php
+++ b/classes/TagHelper.php
@@ -21,6 +21,19 @@ class TagHelper extends \Backend
 		$this->import('Database');
 	}
 
+	public static function getPageObj($jumpTo = null)
+	{
+		global $objPage;
+		if(!empty($jumpTo)) 
+		{
+			return (new PageModel())->findPublishedById($jumpTo);
+		}
+		else
+		{
+			return $objPage;
+		}
+	}
+
 	public function encode($tag)
 	{
 		return str_replace('/', 'x2F', $tag);

--- a/classes/TagHelper.php
+++ b/classes/TagHelper.php
@@ -181,16 +181,13 @@ class TagHelper extends \Backend
 			}
 			if (strlen($target))
 			{
-				$pageArr = array();
-				$objFoundPage = $this->Database->prepare("SELECT id, alias FROM tl_page WHERE id=? OR alias=?")
-					->limit(1)
-					->execute(array($target, $target));
-				$pageArr = ($objFoundPage->numRows) ? $objFoundPage->fetchAssoc() : array();
-				if (count($pageArr))
+				$pageObj = new PageModel();
+				$pageObj = $pageObj::findPublishedByIdOrAlias($target);
+				if (!empty($pageObj))
 				{
 					foreach ($arrTags as $idx => $tag)
 					{
-						$arrTags[$idx]['url'] = StringUtil::ampersand($objPage->getFrontendUrl('/tag/' . $tag['tag']));
+						$arrTags[$idx]['url'] = StringUtil::ampersand($pageObj->getFrontendUrl('/tag/' . $tag['tag']));
 					}
 				}
 			}
@@ -208,11 +205,13 @@ class TagHelper extends \Backend
 						}
 						else
 						{
+							$pageObj = self::getPageObj($objArticle->tags_jumpto);
 							foreach ($arrTags as $idx => $tag)
 							{
-								$arrTags[$idx]['url'] = $objPage->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objArticle->aAlias)) ? $objArticle->aAlias : $objArticle->aId));
+								$arrTags[$idx]['url'] = $pageObj->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objArticle->aAlias)) ? $objArticle->aAlias : $objArticle->aId));
 							}
-							$objTemplate->url = $objPage->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objArticle->aAlias)) ? $objArticle->aAlias : $objArticle->aId));
+							// Whats up here?
+							$objTemplate->url = $pageObj->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objArticle->aAlias)) ? $objArticle->aAlias : $objArticle->aId));
 						}
 						break;
 				}
@@ -281,7 +280,7 @@ class TagHelper extends \Backend
 		$objTemplate->show_tags = $moduleArticle->tags_showtags;
 		if ($moduleArticle->tags_showtags)
 		{
-			$objTemplate->tags = $this->getTagsForArticle($moduleArticle, $moduleArticle->tags_max_tags, $moduleArticle->tags_relevance, $moduleArticlehis->tags_jumpto);
+			$objTemplate->tags = $this->getTagsForArticle($moduleArticle, $moduleArticle->tags_max_tags, $moduleArticle->tags_relevance, $moduleArticle->tags_jumpto);
 		}
 	}
 
@@ -347,24 +346,12 @@ class TagHelper extends \Backend
 		$objTemplate->showTags = $news_showtags;
 		if ($news_showtags)
 		{
-			$pageArr = array();
-			if (strlen($news_jumpto))
-			{
-				$objFoundPage = $this->Database->prepare("SELECT id, alias FROM tl_page WHERE id=?")
-					->limit(1)
-					->execute($news_jumpto);
-				$pageArr = ($objFoundPage->numRows) ? $objFoundPage->fetchAssoc() : array();
-			}
-			if (count($pageArr) == 0)
-			{
-				global $objPage;
-				$pageArr = $objPage->row();
-			}
+			$pageObj = self::getPageObj($news_jumpto);
 			$tags = $this->getTags($row['id'], 'tl_news');
 			$taglist = array();
 			foreach ($tags as $id => $tag)
 			{
-				$strUrl = StringUtil::ampersand($objPage->getFrontendUrl($items . '/tag/' . \TagHelper::encode($tag)));
+				$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl($items . '/tag/' . \TagHelper::encode($tag)));
 				$tags[$id] = '<a href="' . $strUrl . '">' . StringUtil::specialchars($tag) . '</a>';
 				$taglist[$id] = array(
 					'url' => $tags[$id],
@@ -380,24 +367,13 @@ class TagHelper extends \Backend
 	
 	public function getTagsAndTaglistForIdAndTable($id, $table, $jumpto)
 	{
-		$pageArr = array();
-		if (strlen($jumpto))
-		{
-			$objFoundPage = $this->Database->prepare("SELECT id, alias FROM tl_page WHERE id=?")
-				->limit(1)
-				->execute($jumpto);
-			$pageArr = ($objFoundPage->numRows) ? $objFoundPage->fetchAssoc() : array();
-		}
-		if (count($pageArr) == 0)
-		{
-			global $objPage;
-			$pageArr = $objPage->row();
-		}
+		$pageObj = self::getPageObj($jumpto);
+		
 		$tags = $this->getTags($id, $table);
 		$taglist = array();
 		foreach ($tags as $id => $tag)
 		{
-			$strUrl = StringUtil::ampersand($objPage->getFrontendUrl($items . '/tag/' . \TagHelper::encode($tag)));
+			$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl($items . '/tag/' . \TagHelper::encode($tag)));
 			if (strlen(\Environment::get('queryString'))) $strUrl .= "?" . \Environment::get('queryString');
 			$tags[$id] = '<a href="' . $strUrl . '">' . StringUtil::specialchars($tag) . '</a>';
 			$taglist[$id] = array(

--- a/modules/ModuleTagCloud.php
+++ b/modules/ModuleTagCloud.php
@@ -91,15 +91,15 @@ class ModuleTagCloud extends \Module
 	 */
 	protected function showTags()
 	{
+		global $objPage;
 		$this->loadLanguageFile('tl_module');
 		$strUrl = StringUtil::ampersand(\Environment::get('request'));
 		// Get target page
-		$objPageObject = $this->Database->prepare("SELECT id, alias FROM tl_page WHERE id=?")
-			->limit(1)
-			->execute($this->tag_jumpTo);
-		global $objPage;
-		$default = ($objPage != null) ? $objPage->row() : array();
-		$pageArr = ($objPageObject->numRows) ? $objPageObject->fetchAssoc() : $default;
+
+		$pageObj = \TagHelper::getPageObj($this->tag_jumpTo);
+
+		// $default = ($objPage != null) ? $objPage->row() : array();
+		// $pageArr = ($objPageObject->numRows) ? $objPageObject->fetchAssoc() : $default;
 		$strParams = '';
 
 		if ($this->keep_url_params)
@@ -109,9 +109,9 @@ class ModuleTagCloud extends \Module
 
 		foreach ($this->arrTags as $idx => $tag)
 		{
-			if (count($pageArr))
+			if (!empty($pageObj))
 			{
-				$strUrl = StringUtil::ampersand($objPage->getFrontendUrl('/tag/' . \TagHelper::encode($tag['tag_name'])));
+				$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl('/tag/' . \TagHelper::encode($tag['tag_name'])));
 				if (strlen($strParams))
 				{
 					if (strpos($strUrl, '?') !== false)
@@ -144,7 +144,6 @@ class ModuleTagCloud extends \Module
 			}
 			if ($this->checkForContentElementOnPage)
 			{
-				global $objPage;
 				// get articles on page
 				$arrArticles = $this->Database->prepare("SELECT id FROM tl_article WHERE pid = ?")
 					->execute($objPage->id)->fetchEach('id');
@@ -164,10 +163,10 @@ class ModuleTagCloud extends \Module
 		$relatedlist = (strlen(\TagHelper::decode(\Input::get('related')))) ? preg_split("/,/", \TagHelper::decode(\Input::get('related'))) : array();
 		foreach ($this->arrRelated as $idx => $tag)
 		{
-			if (count($pageArr))
+			if (!empty($pageObj))
 			{
 				$allrelated = array_merge($relatedlist, array($tag['tag_name']));
-				$strUrl = StringUtil::ampersand($objPage->getFrontendUrl('/tag/' . \TagHelper::encode(\TagHelper::decode(\Input::get('tag'))) . '/related/' . \TagHelper::encode(join($allrelated, ','))));
+				$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl('/tag/' . \TagHelper::encode(\TagHelper::decode(\Input::get('tag'))) . '/related/' . \TagHelper::encode(join($allrelated, ','))));
 			}
 			$this->arrRelated[$idx]['tag_url'] = $strUrl;
 		}
@@ -198,26 +197,23 @@ class ModuleTagCloud extends \Module
 			$this->Template->lngEmpty = $GLOBALS['TL_LANG']['tl_module']['tag_clear_tags'];
 		}
 		$GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/tags/assets/tagcloud.js';
-		if (count($pageArr))
+		if (!empty($pageObj))
 		{
 			$this->Template->topten = $this->tag_topten;
 			if ($this->tag_topten)
 			{
 				foreach ($this->arrTopTenTags as $idx => $tag)
 				{
-					if (count($pageArr))
+					$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl('/tag/' . \TagHelper::encode($tag['tag_name'])));
+					if (strlen($strParams))
 					{
-						$strUrl = StringUtil::ampersand($objPage->getFrontendUrl('/tag/' . \TagHelper::encode($tag['tag_name'])));
-						if (strlen($strParams))
+						if (strpos($strUrl, '?') !== false)
 						{
-							if (strpos($strUrl, '?') !== false)
-							{
-								$strUrl .= '&amp;' . $strParams;
-							}
-							else
-							{
-								$strUrl .= '?' . $strParams;
-							}
+							$strUrl .= '&amp;' . $strParams;
+						}
+						else
+						{
+							$strUrl .= '?' . $strParams;
 						}
 					}
 					$this->arrTopTenTags[$idx]['tag_url'] = $strUrl;

--- a/modules/ModuleTagContentList.php
+++ b/modules/ModuleTagContentList.php
@@ -86,11 +86,11 @@ class ModuleTagContentList extends \Module
 					{
 						if ($this->linktoarticles)
 						{ // link to articles
-							$articles[] = array('content' => '<a href="' . $objPage->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objArticle->aAlias)) ? $objArticle->aAlias : $objArticle->aId)) . '" title="' . StringUtil::specialchars($objArticle->title) . '">' . $objArticle->title . '</a>', 'tags' => $taglist, 'data' => $objArticle->row());
+							$articles[] = array('content' => '<a href="' . \TagHelper::getPageObj($objArticle->tags_jumpto)->getFrontendUrl('/articles/' . ((!$GLOBALS['TL_CONFIG']['disableAlias'] && strlen($objArticle->aAlias)) ? $objArticle->aAlias : $objArticle->aId)) . '" title="' . StringUtil::specialchars($objArticle->title) . '">' . $objArticle->title . '</a>', 'tags' => $taglist, 'data' => $objArticle->row());
 						}
 						else
 						{ // link to pages
-							$articles[] = array('content' => '<a href="' . $objPage->getFrontendUrl() . '" title="' . StringUtil::specialchars($objArticle->title) . '">' . $objArticle->title . '</a>', 'tags' => $taglist, 'data' => $objArticle->row());
+							$articles[] = array('content' => '<a href="' . \TagHelper::getPageObj($objArticle->tags_jumpto)->getFrontendUrl() . '" title="' . StringUtil::specialchars($objArticle->title) . '">' . $objArticle->title . '</a>', 'tags' => $taglist, 'data' => $objArticle->row());
 						}
 					}
 				}

--- a/modules/ModuleTagScope.php
+++ b/modules/ModuleTagScope.php
@@ -63,10 +63,8 @@ class ModuleTagScope extends \Module
 		$this->Template->lngTags = (strlen($this->clear_text)) ? $this->clear_text : $GLOBALS['TL_LANG']['tl_module']['tags'];
 		$this->Template->jumpTo = $this->jumpTo;
 		$this->Template->arrTags = $this->arrTags;
-		$objPageObject = $this->Database->prepare("SELECT id, alias FROM tl_page WHERE id=?")
-			->limit(1)
-			->execute($this->tag_jumpTo);
-		$pageArr = ($objPageObject->numRows) ? $objPageObject->fetchAssoc() : array();
+
+		$pageObj = \TagHelper::getPageObj($this->tag_jumpTo);
 		$strParams = '';
 		if ($this->keep_url_params)
 		{
@@ -75,9 +73,9 @@ class ModuleTagScope extends \Module
 		$tagurls = array();
 		foreach ($this->arrTags as $idx => $tag)
 		{
-			if (count($pageArr))
+			if (!empty($pageObj))
 			{
-				$strUrl = StringUtil::ampersand($objPage->getFrontendUrl('/tag/' . \TagHelper::encode($tag)));
+				$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl('/tag/' . \TagHelper::encode($tag)));
 				if (strlen($strParams))
 				{
 					if (strpos($strUrl, '?') !== false)
@@ -93,7 +91,7 @@ class ModuleTagScope extends \Module
 			}
 		}
 		$this->Template->tag_urls = $tagurls;
-		$strEmptyUrl = StringUtil::ampersand($objPage->getFrontendUrl());
+		$strEmptyUrl = StringUtil::ampersand($pageObj->getFrontendUrl());
 		if (strlen($strParams))
 		{
 			if (strpos($strEmptyUrl, '?') !== false)
@@ -131,7 +129,7 @@ class ModuleTagScope extends \Module
 						$related = array_slice($newarr, 1);
 						$tagpath .= '/related/' . join($related, ',');
 					}
-					$strUrl = StringUtil::ampersand($objPage->getFrontendUrl($tagpath));
+					$strUrl = StringUtil::ampersand($pageObj->getFrontendUrl($tagpath));
 					if (strlen($strParams))
 					{
 						if (strpos($strUrl, '?') !== false)


### PR DESCRIPTION
Hi o/

mir ist im letzten PR noch ein dummer Fehler unterlaufen. 

Die Links werden falsch generiert, weil ich überall einfach $objPage verwendete, damit verlinkt jeder Tag nur auf die aktuell angezeigte Seite und nicht auf die eingestellte jumpTo-Seite.

In diesem PR bin ich die Funktionen noch mal durchgegangen und habe die korrekten Weiterleitungen eingerichtet.

LG
Sascha