### PR TITLE
Replace öäüß& in class names

### DIFF
--- a/classes/TagList.php
+++ b/classes/TagList.php
@@ -2,6 +2,8 @@
 
 namespace Contao;
 
+use Patchwork\Utf8;
+
 /**
  * Contao Open Source CMS - tags extension
  *
@@ -337,7 +339,7 @@ class TagList extends \System
 	 */
 	protected function getTagNameClass($tag)
 	{
-		return str_replace('"', '', str_replace(' ', '_', $tag));
+		return Utf8::toAscii(StringUtil::standardize($tag));
 	}
 
 	public static function _getTagNameClass($tag)

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "require":{
     "php":">=5.3",
     "contao/core-bundle": "~4.10",
+    "patchwork/utf8": "^1.3",
     "contao-community-alliance/composer-plugin": "~3.0"
   },
   "extra":{


### PR DESCRIPTION
Dieses Update, würde bspw. ö zu o umwandeln. Aus `Küchen` würde `kuchen` und aus `eins & zwei` würde `eins-zwei` werden. Die Lib verwandelt Ö leider nicht in OE - bzw. evt. schon, nur weiß ich nicht wie.

https://github.com/hschottm/tags/issues/59
https://github.com/hschottm/tags/issues/60#issuecomment-694692051