### PR TITLE
Update getAllEvents parameter declaration

### DIFF
--- a/modules/ModuleCalendarTags.php
+++ b/modules/ModuleCalendarTags.php
@@ -16,13 +16,14 @@ class ModuleCalendarTags extends \ModuleCalendar
 	/**
 	 * Get all events of a certain period
 	 *
-	 * @param array   $arrCalendars
-	 * @param integer $intStart
-	 * @param integer $intEnd
-	 *
-	 * @return array
-	 */
-	protected function getAllEvents($arrCalendars, $intStart, $intEnd)
+     * @param array   $arrCalendars
+     * @param integer $intStart
+     * @param integer $intEnd
+     * @param boolean $blnFeatured
+     *
+     * @return array
+     */
+    protected function getAllEvents($arrCalendars, $intStart, $intEnd, $blnFeatured = null)
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (($this->tag_ignore) && !strlen($this->tag_filter)) return $arrAllEvents;

--- a/modules/ModuleEventlistTags.php
+++ b/modules/ModuleEventlistTags.php
@@ -14,10 +14,18 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 
 class ModuleEventlistTags extends \ModuleEventlist
 {
-	/**
-	 * Generate module
-	 */
-	protected function getAllEvents($arrCalendars, $intStart, $intEnd)
+
+    /**
+     * Get all events of a certain period
+     *
+     * @param array   $arrCalendars
+     * @param integer $intStart
+     * @param integer $intEnd
+     * @param boolean $blnFeatured
+     *
+     * @return array
+     */
+    protected function getAllEvents($arrCalendars, $intStart, $intEnd, $blnFeatured = null)
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (($this->tag_ignore) && !strlen($this->tag_filter)) return $arrAllEvents;

--- a/modules/ModuleLastEventsTags.php
+++ b/modules/ModuleLastEventsTags.php
@@ -12,10 +12,18 @@ namespace Contao;
 
 class ModuleLastEventsTags extends \ModuleLastEvents
 {
-	/**
-	 * Generate module
-	 */
-	protected function getAllEvents($arrCalendars, $intStart, $intEnd)
+
+    /**
+     * Get all events of a certain period
+     *
+     * @param array   $arrCalendars
+     * @param integer $intStart
+     * @param integer $intEnd
+     * @param boolean $blnFeatured
+     *
+     * @return array
+     */
+    protected function getAllEvents($arrCalendars, $intStart, $intEnd, $blnFeatured = null)
 	{
 		$arrAllEvents = parent::getAllEvents($arrCalendars, $intStart, $intEnd);
 		if (strlen(\TagHelper::decode(\Input::get('tag'))))


### PR DESCRIPTION
Issue #60 

`$blnFeatured` arugment was missing for Contao 4.10.
See https://github.com/contao/contao/blob/4.10.0/calendar-bundle/src/Resources/contao/classes/Events.php#L108

Caused error:
`Warning: Declaration of Contao\ModuleCalendarTags::getAllEvents($arrCalendars, $intStart, $intEnd) should be compatible with Contao\Events::getAllEvents($arrCalendars, $intStart, $intEnd, $blnFeatured = NULL)`