### PR TITLE
Stop using the session

### DIFF
--- a/classes/TagHelper.php
+++ b/classes/TagHelper.php
@@ -12,6 +12,8 @@ namespace Contao;
 
 class TagHelper extends \Backend
 {
+    public static $config = array();
+
 	/**
 	 * Load the database object
 	 */
@@ -339,10 +341,9 @@ class TagHelper extends \Backend
 	public function parseArticlesHook($objTemplate, $row)
 	{
 		global $objPage;
-		$this->import('Session');
-		$news_showtags = $this->Session->get('news_showtags');
-		$news_jumpto = $this->Session->get('news_jumpto');
-		$tag_named_class = $this->Session->get('news_tag_named_class');
+		$news_showtags = static::$config['news_showtags'];
+		$news_jumpto = static::$config['news_jumpto'];
+		$tag_named_class = static::$config['news_tag_named_class'];
 		$objTemplate->showTags = $news_showtags;
 		if ($news_showtags)
 		{

--- a/modules/ModuleGlobalArticlelist.php
+++ b/modules/ModuleGlobalArticlelist.php
@@ -12,6 +12,10 @@ namespace Contao;
 
 class ModuleGlobalArticlelist extends \Module
 {
+	/**
+	 * @var bool
+	 */
+	private static $block = false;
 
 	/**
 	 * Template
@@ -47,12 +51,12 @@ class ModuleGlobalArticlelist extends \Module
 		global $objPage;
 
 		// block this method to prevent recursive call of getArticle if the HTML of an article is the same as the current article
-		if ($this->Session->get('block'))
+		if (static::$block)
 		{
-			$this->Session->set('block', false);
+			static::$block = false;
 			return;
 		}
-		$this->Session->set('block', true);
+		static::$block = true;
 		$articles = array();
 		$id = $objPage->id;
 
@@ -123,7 +127,7 @@ class ModuleGlobalArticlelist extends \Module
 		$this->Template->tags_activetags = $headlinetags;
 		$this->Template->articles = $articles;
 		$this->Template->empty = $GLOBALS['TL_LANG']['MSC']['emptyarticles'];
-		$this->Session->set('block', false);
+		self::$block = false;
 	}
 }
 

--- a/modules/ModuleNewsArchiveTags.php
+++ b/modules/ModuleNewsArchiveTags.php
@@ -186,9 +186,9 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 	 */
 	protected function compile()
 	{
-		$this->Session->set('news_showtags', $this->news_showtags);
-		$this->Session->set('news_jumpto', $this->tag_jumpTo);
-		$this->Session->set('news_tag_named_class', $this->tag_named_class);
+		\TagHelper::$config['news_showtags'] = $this->news_showtags;
+		\TagHelper::$config['news_jumpto'] = $this->tag_jumpTo;
+		\TagHelper::$config['news_tag_named_class'] = $this->tag_named_class;
 		if ((strlen(\TagHelper::decode(\Input::get('tag'))) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
@@ -238,9 +238,9 @@ class ModuleNewsArchiveTags extends \ModuleNewsArchive
 		{
 			parent::compile();
 		}
-		$this->Session->set('news_showtags', '');
-		$this->Session->set('news_jumpto', '');
-		$this->Session->set('news_tag_named_class', '');
+		unset(\TagHelper::$config['news_showtags']);
+		unset(\TagHelper::$config['news_jumpto']);
+		unset(\TagHelper::$config['news_tag_named_class']);
 	}
 }
 

--- a/modules/ModuleNewsListTags.php
+++ b/modules/ModuleNewsListTags.php
@@ -195,9 +195,9 @@ class ModuleNewsListTags extends \ModuleNewsList
 	 */
 	protected function compile()
 	{
-		$this->Session->set('news_showtags', $this->news_showtags);
-		$this->Session->set('news_jumpto', $this->tag_jumpTo);
-		$this->Session->set('news_tag_named_class', $this->tag_named_class);
+		\TagHelper::$config['news_showtags'] = $this->news_showtags;
+		\TagHelper::$config['news_jumpto'] = $this->tag_jumpTo;
+		\TagHelper::$config['news_tag_named_class'] = $this->tag_named_class;
 		if ((strlen(\TagHelper::decode(\Input::get('tag'))) && (!$this->tag_ignore)) || (strlen($this->tag_filter)))
 		{
 			$tagids = array();
@@ -247,9 +247,9 @@ class ModuleNewsListTags extends \ModuleNewsList
 		{
 			parent::compile();
 		}
-		$this->Session->set('news_showtags', '');
-		$this->Session->set('news_jumpto', '');
-		$this->Session->set('news_tag_named_class', '');
+		unset(\TagHelper::$config['news_showtags']);
+		unset(\TagHelper::$config['news_jumpto']);
+		unset(\TagHelper::$config['news_tag_named_class']);
 	}
 }
 

--- a/modules/ModuleNewsReaderTags.php
+++ b/modules/ModuleNewsReaderTags.php
@@ -20,13 +20,13 @@ class ModuleNewsReaderTags extends \ModuleNewsReader
 	 */
 	protected function compile()
 	{
-		$this->Session->set('news_showtags', $this->news_showtags);
-		$this->Session->set('news_jumpto', $this->tag_jumpTo);
-		$this->Session->set('news_tag_named_class', $this->tag_named_class);
+		\TagHelper::$config['news_showtags'] = $this->news_showtags;
+		\TagHelper::$config['news_jumpto'] = $this->tag_jumpTo;
+		\TagHelper::$config['news_tag_named_class'] = $this->tag_named_class;
 		parent::compile();
-		$this->Session->set('news_showtags', '');
-		$this->Session->set('news_jumpto', '');
-		$this->Session->set('news_tag_named_class', '');
+		unset(\TagHelper::$config['news_showtags']);
+		unset(\TagHelper::$config['news_jumpto']);
+		unset(\TagHelper::$config['news_tag_named_class']);
 	}
 }
 

--- a/modules/ModuleTaggedArticleList.php
+++ b/modules/ModuleTaggedArticleList.php
@@ -22,6 +22,11 @@ namespace Contao;
 class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 {
 	/**
+	 * @var bool
+	 */
+	private static $block = false;
+
+	/**
 	 * Template
 	 * @var string
 	 */
@@ -172,12 +177,12 @@ class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 		global $objPage;
 
 		// block this method to prevent recursive call of getArticle if the HTML of an article is the same as the current article
-		if ($this->Session->get('block'))
+		if (static::$block)
 		{
-			$this->Session->set('block', false);
+			static::$block = false;
 			return;
 		}
-		$this->Session->set('block', true);
+		static::$block = true;
 		$articles = array();
 		$id = $objPage->id;
 
@@ -275,6 +280,6 @@ class ModuleTaggedArticleList extends \ModuleGlobalArticlelist
 		$this->Template->tags_activetags = $headlinetags;
 		$this->Template->articles = $articles;
 		$this->Template->empty = $GLOBALS['TL_LANG']['MSC']['emptyarticles'];
-		$this->Session->set('block', false);
+		static::$block = false;
 	}
 }


### PR DESCRIPTION
Using the session to store runtime behaviour is not ideal, because it will always start the session for the user and disable the Contao cache. Since the properties seem only used for the current request, we don't need the session to transport them to the next page view.

I have updated some of the places that should affect the front end. There is also a lot of session usage in the DCA callbacks, but I couldn't figure out how that is used (it is only read but never set…?). It shouldn't affect the frontend though.