### PR TITLE
Various fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,16 @@
     }
   ],
   "require":{
-    "php": "^8.0",
+    "php": "^8.1",
     "contao/core-bundle": "~5.3",
     "contao-community-alliance/composer-plugin":"~3.2"
   },
   "require-dev": {
     "contao/calendar-bundle": "~5.3",
     "contao/comments-bundle": "~5.3",
-    "contao/faq-bundle": "~5.3"
+    "contao/faq-bundle": "~5.3",
+    "contao/news-bundle": "~5.3",
+    "contao/manager-plugin": "^2.13"
   },
   "conflict": {
 		"contao/manager-plugin": "<2.0 || >=3.0"

--- a/src/EventListener/DataContainer/ArticleCallbackListener.php
+++ b/src/EventListener/DataContainer/ArticleCallbackListener.php
@@ -5,13 +5,11 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class ArticleCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {

--- a/src/EventListener/DataContainer/CalendarCallbackListener.php
+++ b/src/EventListener/DataContainer/CalendarCallbackListener.php
@@ -5,13 +5,11 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class CalendarCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {

--- a/src/EventListener/DataContainer/ContentCallbackListener.php
+++ b/src/EventListener/DataContainer/ContentCallbackListener.php
@@ -5,13 +5,11 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class ContentCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {

--- a/src/EventListener/DataContainer/FaqCallbackListener.php
+++ b/src/EventListener/DataContainer/FaqCallbackListener.php
@@ -5,13 +5,11 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class FaqCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {

--- a/src/EventListener/DataContainer/FileCallbackListener.php
+++ b/src/EventListener/DataContainer/FileCallbackListener.php
@@ -4,14 +4,13 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
+use Contao\FilesModel;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class FileCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {

--- a/src/EventListener/DataContainer/MemberCallbackListener.php
+++ b/src/EventListener/DataContainer/MemberCallbackListener.php
@@ -5,13 +5,11 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 class MemberCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {

--- a/src/EventListener/DataContainer/NewsCallbackListener.php
+++ b/src/EventListener/DataContainer/NewsCallbackListener.php
@@ -5,7 +5,6 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Contao\ContentModel;
 
@@ -13,7 +12,6 @@ use Contao\ContentModel;
 class NewsCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
         private readonly RequestStack $requestStack
     )

--- a/src/EventListener/DataContainer/PageCallbackListener.php
+++ b/src/EventListener/DataContainer/PageCallbackListener.php
@@ -5,12 +5,10 @@ namespace Hschottm\TagsBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PageCallbackListener
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, 
         private readonly Connection $db,
     )
     {
@@ -29,7 +27,7 @@ class PageCallbackListener
 		while (($row = $arrArticles->fetchAssociative()) !== false) {
 			$arrContentElements = $this->db->prepare("SELECT DISTINCT id FROM tl_content WHERE pid = ?")
 				->executeQuery(array($row['id']));
-			while (($crow = $arrContentElements->fetchAssociative()) !== false) 
+			while (($crow = $arrContentElements->fetchAssociative()) !== false)
 			{
 				$this->db->prepare("DELETE FROM tl_tag WHERE from_table = ? AND tid = ?")
 					->executeQuery(array('tl_content', $crow['id']));

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -24,49 +24,41 @@ services:
     contao.listener.data_container.article:
         class: Hschottm\TagsBundle\EventListener\DataContainer\ArticleCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 
     contao.listener.data_container.calendar:
         class: Hschottm\TagsBundle\EventListener\DataContainer\CalendarCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 
     contao.listener.data_container.content:
         class: Hschottm\TagsBundle\EventListener\DataContainer\ContentCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 
     contao.listener.data_container.faq:
         class: Hschottm\TagsBundle\EventListener\DataContainer\FaqCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 
     contao.listener.data_container.file:
         class: Hschottm\TagsBundle\EventListener\DataContainer\FileCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 
     contao.listener.data_container.member:
-        class: Hschottm\TagsBundle\EventListener\DataContainer\MemberrCallbackListener
+        class: Hschottm\TagsBundle\EventListener\DataContainer\MemberCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 
     contao.listener.data_container.news:
         class: Hschottm\TagsBundle\EventListener\DataContainer\NewsCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
             - '@request_stack'
 
     contao.listener.data_container.page:
         class: Hschottm\TagsBundle\EventListener\DataContainer\PageCallbackListener
         arguments:
-            - '@translator'
             - '@database_connection'
 

--- a/src/Resources/contao/dca/tl_files.php
+++ b/src/Resources/contao/dca/tl_files.php
@@ -27,9 +27,6 @@ if (!in_array('tl_files', $disabledObjects))
     ->applyToPalette('default', 'tl_files');
 
     //$GLOBALS['TL_DCA']['tl_files']['palettes']['default'] = str_replace(';meta', ';tags;meta', $GLOBALS['TL_DCA']['tl_files']['palettes']['default']);
-
-	$GLOBALS['TL_DCA']['tl_files']['config']['ondelete_callback'][] = array('tl_files_tags', 'removeContentElement');
-	$GLOBALS['TL_DCA']['tl_files']['config']['oncopy_callback'][] = array('tl_files_tags', 'onCopy');
 }
 
 $GLOBALS['TL_DCA']['tl_files']['fields']['tags'] = array


### PR DESCRIPTION
1. Increased min PHP version as the code uses the `readonly` property attribute (a4eec0be31d5e308c1f6235247ca388150fe6d18)
2. Removed unused arguments, fix class name typo and added a missing use declaration (09c6543431614bab5d0f7372c6224d1eb35a28db)
3. Removed old hook configs which lead to a class not exists error (cf8350382ba41fdec264a5d2e6fcfe0973d8cfa1)